### PR TITLE
Bugfix: Edge cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Documentation of release versions of `nacc-attribute-deriver`
 ## 1.3.1
 
 * Fixes issue in `_create_contributing_diagnosis` and `_create_dementia` where the returned value can be an empty list - needs to be treated as `None`
-* Fixes `_create_uds_race` to only evaluate if this is an initial packet (otherwise date gets set to latest form which isn't where the value actually comes from)
+* Fixes `_create_uds_race` to only evaluate if this is an initial packet (previously date got set to latest form which wasn't accurate)
 
 ## 1.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 Documentation of release versions of `nacc-attribute-deriver`
 
+## 1.3.1
+
+* Fixes issue in `_create_contributing_diagnosis` and `_create_dementia` where the returned value can be an empty list - needs to be treated as `None
+* Fixes `_create_uds_race` to only evaluate if this is an initial packet (otherwise date gets set to latest form which isn't where the value actually comes from)
+
 ## 1.3.0
 
 * Adds `historic_apoe` rule to support historical APOE values from sources other than NCRAD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Documentation of release versions of `nacc-attribute-deriver`
 
 ## 1.3.1
 
-* Fixes issue in `_create_contributing_diagnosis` and `_create_dementia` where the returned value can be an empty list - needs to be treated as `None
+* Fixes issue in `_create_contributing_diagnosis` and `_create_dementia` where the returned value can be an empty list - needs to be treated as `None`
 * Fixes `_create_uds_race` to only evaluate if this is an initial packet (otherwise date gets set to latest form which isn't where the value actually comes from)
 
 ## 1.3.0

--- a/nacc_attribute_deriver/BUILD
+++ b/nacc_attribute_deriver/BUILD
@@ -7,7 +7,7 @@ python_distribution(
     sdist=True,
     provides=python_artifact(
         name="nacc-attribute-deriver",
-        version="1.3.0",
+        version="1.3.1",
         description="Uses rules to derive attribute values from file data",
         author="NACC",
         author_email="nacchelp@uw.edu",

--- a/nacc_attribute_deriver/attributes/mqt/cognitive.py
+++ b/nacc_attribute_deriver/attributes/mqt/cognitive.py
@@ -111,7 +111,7 @@ class CognitiveAttributeCollection(AttributeCollection):
 
     def map_attributes(
         self, mapping: Mapping[str, str], expected_value: int
-    ) -> List[str]:
+    ) -> Optional[List[str]]:
         """Returns the list of string values for the attributes in the mapping
         for which the value matches the expected value.
 
@@ -125,9 +125,10 @@ class CognitiveAttributeCollection(AttributeCollection):
         attributes = self.__filter_attributes(
             attributes=list(mapping.keys()), expected_value=expected_value
         )
-        return list({mapping[attribute] for attribute in attributes})
+        result = list({mapping[attribute] for attribute in attributes})
+        return result if result else None
 
-    def _create_contributing_diagnosis(self) -> DateTaggedValue[List[str]]:
+    def _create_contributing_diagnosis(self) -> DateTaggedValue[Optional[List[str]]]:
         """Mapped from all possible contributing diagnosis."""
         self.__derived.assert_required(["naccalzp", "nacclbdp"])
         return DateTaggedValue(
@@ -135,7 +136,7 @@ class CognitiveAttributeCollection(AttributeCollection):
             date=self.__uds.get_date(),
         )
 
-    def _create_dementia(self) -> DateTaggedValue[List[str]]:
+    def _create_dementia(self) -> DateTaggedValue[Optional[List[str]]]:
         """Mapped from all dementia types."""
         self.__derived.assert_required(["naccppa", "naccbvft", "nacclbds"])
         return DateTaggedValue(
@@ -143,7 +144,7 @@ class CognitiveAttributeCollection(AttributeCollection):
             date=self.__uds.get_date(),
         )
 
-    def _create_cognitive_status(self) -> DateTaggedValue[Optional[int]]:
+    def _create_cognitive_status(self) -> DateTaggedValue[int]:
         """Mapped from NACCUDSD."""
         self.__derived.assert_required(["naccudsd"])
 
@@ -160,7 +161,7 @@ class CognitiveAttributeCollection(AttributeCollection):
             date=self.__uds.get_date(),
         )
 
-    def _create_global_cdr(self) -> Optional[DateTaggedValue[float]]:
+    def _create_global_cdr(self) -> DateTaggedValue[float]:
         """Mapped from CDRGLOB."""
         cdrglob = self.__uds.get_value("cdrglob")
 

--- a/nacc_attribute_deriver/attributes/mqt/demographics.py
+++ b/nacc_attribute_deriver/attributes/mqt/demographics.py
@@ -57,7 +57,7 @@ class DemographicsAttributeCollection(AttributeCollection):
     def _create_uds_primary_language(self) -> Optional[DateTaggedValue[str]]:
         """UDS primary language.
 
-        Only for initial forms.
+        Only set in initial packet.
         """
         if not self.__uds.is_initial():
             return None
@@ -116,8 +116,14 @@ class DerivedDemographicsAttributeCollection(AttributeCollection):
         }
     )
 
-    def _create_uds_race(self) -> DateTaggedValue[str]:
-        """UDS race."""
+    def _create_uds_race(self) -> Optional[DateTaggedValue[str]]:
+        """UDS race.
+
+        Only set in initial packet.
+        """
+        if not self.__uds.is_initial():
+            return None
+
         self.__derived.assert_required(["naccnihr"])
         return DateTaggedValue(
             value=self.RACE_MAPPING.get(


### PR DESCRIPTION
Fixes some edge cases found while testing

* Fixes issue in `_create_contributing_diagnosis` and `_create_dementia` where the returned value can be an empty list - needs to be treated as `None`
* Fixes `_create_uds_race` to only evaluate if this is an initial packet (otherwise date gets set to latest form which isn't where the value actually comes from)