### PR TITLE
Refactor/annotate expressions

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,6 +7,7 @@
         "charliermarsh",
         "devcontainers",
         "exomechip",
+        "formdate",
         "formver",
         "gwas",
         "jsburckhardt",

--- a/nacc_attribute_deriver/attributes/attribute_collection.py
+++ b/nacc_attribute_deriver/attributes/attribute_collection.py
@@ -132,7 +132,7 @@ class AttributeCollection(object, metaclass=AttributeCollectionRegistry):
         return None
 
     @staticmethod
-    def is_target_int(value: Union[int, str], target: int) -> bool:
+    def is_target_int(value: Union[int, str, None], target: int) -> bool:
         """Check whether the value is the specified target int. This might be
         overkill but wanted it to handle str/int comparisons.
 

--- a/nacc_attribute_deriver/attributes/base/scan_namespace.py
+++ b/nacc_attribute_deriver/attributes/base/scan_namespace.py
@@ -54,11 +54,13 @@ class SCANNamespace(RawNamespace):
     # get functions for common values
     def get_tracer(self, field: str, scope: SCANPETScope) -> Optional[str]:
         """Get the tracer string."""
-        tracer = None
+        self.assert_required(SCAN_REQUIRED_FIELDS[scope])
+        attribute_value = self.get_value(field)
+        if attribute_value is None:
+            return None
+
         try:
-            self.assert_required(SCAN_REQUIRED_FIELDS[scope])
-            tracer = float(self.get_value(field))
-            tracer = int(tracer)  # can't call int directly on string-float
+            tracer = int(float(attribute_value))
         except (ValueError, TypeError):
             return None
 
@@ -66,11 +68,13 @@ class SCANNamespace(RawNamespace):
 
     def get_scan_type(self, field: str, scope: SCANPETScope) -> Optional[str]:
         """Get the scan type from the tracer."""
-        tracer = None
+        self.assert_required(SCAN_REQUIRED_FIELDS[scope])
+        attribute_value = self.get_value(field)
+        if attribute_value is None:
+            return None
+
         try:
-            self.assert_required(SCAN_REQUIRED_FIELDS[scope])
-            tracer = float(self.get_value(field))
-            tracer = int(tracer)
+            tracer = int(float(attribute_value))
         except (ValueError, TypeError):
             return None
 

--- a/nacc_attribute_deriver/attributes/base/uds_namespace.py
+++ b/nacc_attribute_deriver/attributes/base/uds_namespace.py
@@ -27,20 +27,21 @@ class UDSNamespace(FormNamespace):
 
         return False
 
-    def normalized_formver(self) -> int:
+    def normalized_formver(self) -> Optional[int]:
         """Returns the normalized form version.
 
         Handles cases where the form version is listed as 3.2 for
         example.
         """
-        try:
-            raw_formver = self.get_value("formver")
-            formver = int(float(raw_formver))
-        except (ValueError, TypeError) as e:
-            msg = f"Current file does not have a numerical formver: {raw_formver}"
-            raise InvalidFieldError(msg) from e
+        attribute_value = self.get_value("formver")
+        if attribute_value is None:
+            return None
 
-        return formver
+        try:
+            return int(float(attribute_value))
+        except (ValueError, TypeError) as e:
+            msg = f"Current file does not have a numerical formver: {attribute_value}"
+            raise InvalidFieldError(msg) from e
 
     def generate_uds_dob(self) -> Optional[date]:
         """Creates UDS DOB, which is used to calculate ages."""
@@ -48,7 +49,11 @@ class UDSNamespace(FormNamespace):
         birthyr = self.get_value("birthyr")
         formdate = self.get_value("visitdate")
 
-        if None in [birthmo, birthyr, formdate]:
+        if birthmo is None:
+            return None
+        if birthyr is None:
+            return None
+        if formdate is None:
             return None
 
         return datetime(int(birthyr), int(birthmo), 1).date()

--- a/nacc_attribute_deriver/attributes/mqt/cognitive.py
+++ b/nacc_attribute_deriver/attributes/mqt/cognitive.py
@@ -82,7 +82,9 @@ class CognitiveAttributeCollection(AttributeCollection):
         }
     )
 
-    def __filter_attributes(self, attributes: List[str], expected_value: int):
+    def __filter_attributes(
+        self, attributes: List[str], expected_value: int
+    ) -> List[str]:
         """Returns a list of the attributes that have the expected value.
 
         Args:

--- a/nacc_attribute_deriver/attributes/mqt/cognitive.py
+++ b/nacc_attribute_deriver/attributes/mqt/cognitive.py
@@ -129,41 +129,47 @@ class CognitiveAttributeCollection(AttributeCollection):
         )
         return list({mapping[attribute] for attribute in attributes})
 
-    def _create_contributing_diagnosis(self) -> DateTaggedValue[List[str]]:
+    def _create_contributing_diagnosis(self) -> Optional[DateTaggedValue[List[str]]]:
         """Mapped from all possible contributing diagnosis."""
         self.__derived.assert_required(["naccalzp", "nacclbdp"])
+        attribute_value = self.map_attributes(self.DIAGNOSIS_MAPPINGS, expected_value=2)
+        if not attribute_value:
+            return None
+
         return DateTaggedValue(
-            value=self.map_attributes(self.DIAGNOSIS_MAPPINGS, expected_value=2),
+            value=attribute_value,
             date=self.__uds.get_date(),
         )
 
-    def _create_dementia(self) -> DateTaggedValue[List[str]]:
+    def _create_dementia(self) -> Optional[DateTaggedValue[List[str]]]:
         """Mapped from all dementia types."""
         self.__derived.assert_required(["naccppa", "naccbvft", "nacclbds"])
+        attribute_value = self.map_attributes(self.DEMENTIA_MAPPINGS, expected_value=1)
+        if not attribute_value:
+            return None
+
         return DateTaggedValue(
-            value=self.map_attributes(self.DEMENTIA_MAPPINGS, expected_value=1),
+            value=attribute_value,
             date=self.__uds.get_date(),
         )
 
-    def _create_cognitive_status(self) -> DateTaggedValue[Optional[int]]:
+    def _create_cognitive_status(self) -> Optional[DateTaggedValue[int]]:
         """Mapped from NACCUDSD."""
         self.__derived.assert_required(["naccudsd"])
 
-        return DateTaggedValue(
-            value=self.__derived.get_value("naccudsd"),
-            date=self.__uds.get_date(),
+        return self.__derived.create_dated_value(
+            attribute="naccudsd", date=self.__uds.get_date()
         )
 
-    def _create_etpr(self) -> DateTaggedValue[int]:
+    def _create_etpr(self) -> Optional[DateTaggedValue[int]]:
         """Mapped from NACCETPR."""
         self.__derived.assert_required(["naccetpr"])
-        return DateTaggedValue(
-            value=self.__derived.get_value("naccetpr"),
-            date=self.__uds.get_date(),
+
+        return self.__derived.create_dated_value(
+            attribute="naccetpr", date=self.__uds.get_date()
         )
 
     def _create_global_cdr(self) -> Optional[DateTaggedValue[float]]:
         """Mapped from CDRGLOB."""
-        cdrglob = self.__uds.get_value("cdrglob")
 
-        return DateTaggedValue(value=cdrglob, date=self.__uds.get_date())
+        return self.__uds.get_dated_value("cdrglob")

--- a/nacc_attribute_deriver/attributes/mqt/longitudinal.py
+++ b/nacc_attribute_deriver/attributes/mqt/longitudinal.py
@@ -3,6 +3,8 @@
 Assumes NACC-derived variables are already set
 """
 
+from typing import Optional
+
 from nacc_attribute_deriver.attributes.attribute_collection import AttributeCollection
 from nacc_attribute_deriver.attributes.base.namespace import (
     SubjectDerivedNamespace,
@@ -11,23 +13,32 @@ from nacc_attribute_deriver.attributes.base.namespace import (
 from nacc_attribute_deriver.attributes.base.uds_namespace import (
     UDSNamespace,
 )
+from nacc_attribute_deriver.symbol_table import SymbolTable
 from nacc_attribute_deriver.utils.date import get_unique_years
 
 
 class LongitudinalAttributeCollection(AttributeCollection):
     """Class to collect longitudinal attributes."""
 
-    def __init__(self, table):
+    def __init__(self, table: SymbolTable):
         self.__uds = UDSNamespace(table)
         self.__subject_derived = SubjectDerivedNamespace(table)
         self.__subject_info = SubjectInfoNamespace(table)
 
-    def _create_total_uds_visits(self) -> int:
+    def _create_total_uds_visits(self) -> Optional[int]:
         """Total number of UDS visits."""
         self.__subject_derived.assert_required(["uds-visitdates"])
-        return len(self.__subject_derived.get_value("uds-visitdates"))
+        attribute_value = self.__subject_derived.get_value("uds-visitdates")
+        if attribute_value is None:
+            return None
 
-    def _create_years_of_uds(self) -> int:
+        return len(attribute_value)
+
+    def _create_years_of_uds(self) -> Optional[int]:
         """Creates subject.info.longitudinal-data.uds.year-count."""
         self.__subject_derived.assert_required(["uds-visitdates"])
-        return len(get_unique_years(self.__subject_derived.get_value("uds-visitdates")))
+        attribute_value = self.__subject_derived.get_value("uds-visitdates")
+        if attribute_value is None:
+            return None
+
+        return len(get_unique_years(attribute_value))

--- a/nacc_attribute_deriver/attributes/mqt/study_parameters.py
+++ b/nacc_attribute_deriver/attributes/mqt/study_parameters.py
@@ -25,6 +25,7 @@ class StudyParametersAttributeCollection(AttributeCollection):
         """Keeps track of available UDS versions."""
         formver = self.__file.normalized_formver()
         versions = self.__subject_info.get_value("study-parameters.uds.versions", [])
+        assert versions is not None
         versions = {
             version
             for version in versions

--- a/nacc_attribute_deriver/attributes/nacc/genetics/ncrad.py
+++ b/nacc_attribute_deriver/attributes/nacc/genetics/ncrad.py
@@ -9,6 +9,7 @@ from typing import Mapping, Tuple
 
 from nacc_attribute_deriver.attributes.attribute_collection import AttributeCollection
 from nacc_attribute_deriver.attributes.base.namespace import RawNamespace
+from nacc_attribute_deriver.schema.errors import InvalidFieldError
 from nacc_attribute_deriver.symbol_table import SymbolTable
 
 
@@ -64,20 +65,15 @@ class HistoricalNCRADAttributeCollection(AttributeCollection):
 
         <subject>_historic_apoe_genotype.json
         """
-        apoe = self.__apoe.get_value("apoe")
-
-        try:
-            apoe = int(apoe)
-        except (TypeError, ValueError):
-            apoe = None
+        apoe = self.__apoe.get_int_value("apoe")
 
         # while sas code handles consistency, just do a sanity check
         # to make sure entire rows lines up, else there's an issue
         if apoe is not None:
             for field in ["apoecenter", "apoenp", "apoeadgc", "adcapoe", "apoecomm"]:
-                source_apoe = self.__apoe.get_value(field)
-                if source_apoe:
-                    assert source_apoe == str(apoe), (
+                source_apoe = self.__apoe.get_int_value(field)
+                if source_apoe is not None and source_apoe != apoe:
+                    raise InvalidFieldError(
                         f"Source {field} with value {source_apoe} does not match "
                         + f"expected apoe value {apoe}"
                     )

--- a/nacc_attribute_deriver/attributes/nacc/genetics/niagads.py
+++ b/nacc_attribute_deriver/attributes/nacc/genetics/niagads.py
@@ -4,6 +4,8 @@ Right now these should all come from the imported GWAS data under
 <subject>_niagads_availability.json
 """
 
+from typing import Optional
+
 from nacc_attribute_deriver.attributes.attribute_collection import AttributeCollection
 from nacc_attribute_deriver.attributes.base.namespace import RawNamespace
 from nacc_attribute_deriver.symbol_table import SymbolTable
@@ -24,29 +26,31 @@ class NIAGADSAttributeCollection(AttributeCollection):
             ]
         )
 
-    def _evaluate_investigator(self, value: str) -> int:
+    def _evaluate_investigator(self, attribute: str) -> Optional[int]:
         """Evaluate investigator. If null/missing (set to None or "0") then
         return 0, else return 1.
 
         Args:
             value: The value to evaluate.
         """
-        return 1 if value and str(value) != "0" else 0
+        attribute_value = self.__niagads.get_value(attribute)
+        if attribute_value is None:
+            return None
 
-    def _create_niagads_gwas(self) -> int:
+        return 1 if attribute_value and str(attribute_value) != "0" else 0
+
+    def _create_niagads_gwas(self) -> Optional[int]:
         """NIAGADS GWAS investigator availability."""
-        return self._evaluate_investigator(self.__niagads.get_value("niagads_gwas"))
+        return self._evaluate_investigator("niagads_gwas")
 
-    def _create_niagads_exome(self) -> int:
+    def _create_niagads_exome(self) -> Optional[int]:
         """NIAGADS ExomeChip investigator availability."""
-        return self._evaluate_investigator(
-            self.__niagads.get_value("niagads_exomechip")
-        )
+        return self._evaluate_investigator("niagads_exomechip")
 
-    def _create_niagads_wgs(self) -> int:
+    def _create_niagads_wgs(self) -> Optional[int]:
         """NIAGADS WGS investigator availability."""
-        return self._evaluate_investigator(self.__niagads.get_value("niagads_wgs"))
+        return self._evaluate_investigator("niagads_wgs")
 
-    def _create_niagads_wes(self) -> int:
+    def _create_niagads_wes(self) -> Optional[int]:
         """NIAGADS WES investigator availability."""
-        return self._evaluate_investigator(self.__niagads.get_value("niagads_wes"))
+        return self._evaluate_investigator("niagads_wes")

--- a/nacc_attribute_deriver/attributes/nacc/modules/mds/form_mds.py
+++ b/nacc_attribute_deriver/attributes/nacc/modules/mds/form_mds.py
@@ -12,7 +12,7 @@ class MDSFormAttributeCollection(AttributeCollection):
         self.__mds = FormNamespace(table)
 
     def _create_mds_death_date(self) -> Optional[date]:
-        if not self.is_target_int(self.__mds.get_value("vitalst"), 2):
+        if self.is_target_int(self.__mds.get_int_value("vitalst"), 2):
             return None
 
         year = self.__mds.get_value("deathyr")  # can be 9999
@@ -21,5 +21,5 @@ class MDSFormAttributeCollection(AttributeCollection):
 
         return create_death_date(year=year, month=month, day=day)
 
-    def _create_mds_vitalst(self) -> int:
-        return self.__mds.get_value("vitalst")
+    def _create_mds_vitalst(self) -> Optional[int]:
+        return self.__mds.get_int_value("vitalst")

--- a/nacc_attribute_deriver/attributes/nacc/modules/milestone/form_milestone.py
+++ b/nacc_attribute_deriver/attributes/nacc/modules/milestone/form_milestone.py
@@ -12,7 +12,7 @@ class MilestoneAttributeCollection(AttributeCollection):
         self.__milestone = FormNamespace(table)
 
     def _create_milestone_death_date(self) -> Optional[date]:
-        if not self.is_target_int(self.__milestone.get_value("deceased"), 1):
+        if not self.is_target_int(self.__milestone.get_int_value("deceased"), 1):
             return None
 
         year = self.__milestone.get_value("deathyr")

--- a/nacc_attribute_deriver/attributes/nacc/modules/uds/form_d1.py
+++ b/nacc_attribute_deriver/attributes/nacc/modules/uds/form_d1.py
@@ -285,9 +285,9 @@ class UDSFormD1Attribute(AttributeCollection):
         try:
             if naccnorm is not None and int(naccnorm) == 0:
                 return 0
-
-            return int(self.__uds.get_value("normcog"))
         except (ValueError, TypeError):
             pass
 
-        return 1
+        normcog = self.__uds.get_int_value("normcog")
+
+        return normcog if normcog else 1

--- a/nacc_attribute_deriver/attributes/nacc/modules/uds/genetics_derived.py
+++ b/nacc_attribute_deriver/attributes/nacc/modules/uds/genetics_derived.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from nacc_attribute_deriver.attributes.attribute_collection import AttributeCollection
 from nacc_attribute_deriver.attributes.base.namespace import SubjectDerivedNamespace
 from nacc_attribute_deriver.symbol_table import SymbolTable
@@ -7,18 +9,18 @@ class GeneticsDerivedAttributeCollection(AttributeCollection):
     def __init__(self, table: SymbolTable):
         self.__subject_derived = SubjectDerivedNamespace(table)
 
-    def _create_ngdsgwas(self) -> int:
+    def _create_ngdsgwas(self) -> Optional[int]:
         """NIAGADS GWAS investigator availability."""
-        return self.__subject_derived.get_value("niagads_gwas")
+        return self.__subject_derived.get_int_value("niagads_gwas")
 
-    def _create_ngdsexom(self) -> int:
+    def _create_ngdsexom(self) -> Optional[int]:
         """NIAGADS ExomeChip investigator availability."""
-        return self.__subject_derived.get_value("niagads_exome")
+        return self.__subject_derived.get_int_value("niagads_exome")
 
-    def _create_ngdswgs(self) -> int:
+    def _create_ngdswgs(self) -> Optional[int]:
         """NIAGADS WGS investigator availability."""
-        return self.__subject_derived.get_value("niagads_wgs")
+        return self.__subject_derived.get_int_value("niagads_wgs")
 
-    def _create_ngdswes(self) -> int:
+    def _create_ngdswes(self) -> Optional[int]:
         """NIAGADS WES investigator availability."""
-        return self.__subject_derived.get_value("niagads_wes")
+        return self.__subject_derived.get_int_value("niagads_wes")

--- a/nacc_attribute_deriver/schema/operation.py
+++ b/nacc_attribute_deriver/schema/operation.py
@@ -1,16 +1,45 @@
-"""Defines the operations to be performed on derived variables. Uses a
-metaclass to keep track of operation types.
+"""Defines the operations to be performed on derived variables.
 
-This kind of feels overengineered?
+Uses a metaclass to keep track of operation types.
 """
 
 from abc import abstractmethod
 from datetime import date
-from typing import Any, ClassVar, Dict
+from typing import Any, ClassVar, Dict, List, TypeAlias, Union, get_args, get_origin
 
 from nacc_attribute_deriver.attributes.base.namespace import DateTaggedValue
 from nacc_attribute_deriver.symbol_table import SymbolTable
 from nacc_attribute_deriver.utils.date import datetime_from_form_date
+
+
+class NoAssignment:
+    pass
+
+
+def get_optional_type(expression_type: type) -> type:
+    origin = get_origin(expression_type)
+    args = get_args(expression_type)
+    if origin is Union and type(None) in args:
+        return args[0]
+    return expression_type
+
+
+def get_list_type(expression_type: type) -> type:
+    origin = get_origin(expression_type)
+    if origin is list:
+        return get_args(expression_type)[0]
+    return expression_type
+
+
+def get_date_tagged_type(expression_type: type) -> type:
+    if hasattr(expression_type, "__pydantic_generic_metadata__"):
+        origin = expression_type.__pydantic_generic_metadata__["origin"]  # type: ignore
+        if origin is DateTaggedValue:
+            args = expression_type.__pydantic_generic_metadata__[  # type: ignore
+                "args"
+            ]  # type: ignore
+            return args[0]  # type: ignore
+    return expression_type
 
 
 class OperationError(Exception):
@@ -31,6 +60,11 @@ class OperationRegistry(type):
 
 class Operation(object, metaclass=OperationRegistry):
     LABEL: str | None = None
+
+    @classmethod
+    def attribute_type(cls, expression_type: type) -> type:
+        """Returns the type assigned to the attribute by this operation."""
+        return NoAssignment
 
     @classmethod
     def create(cls, label: str) -> "Operation":
@@ -62,13 +96,18 @@ class Operation(object, metaclass=OperationRegistry):
 class UpdateOperation(Operation):
     LABEL = "update"
 
+    @classmethod
+    def attribute_type(cls, expression_type: type) -> type:
+        # TODO: allow for stripping datetaggedvalue
+        return get_optional_type(expression_type)
+
     def evaluate(  # type: ignore
         self, *, table: SymbolTable, value: Any, attribute: str
     ) -> None:
         """Simply updates the location."""
 
         if isinstance(value, DateTaggedValue):
-            value = value.value
+            value = value.value  # type: ignore
         if value is None:
             return
 
@@ -81,13 +120,20 @@ class UpdateOperation(Operation):
 class SetOperation(Operation):
     LABEL = "set"
 
+    @classmethod
+    def attribute_type(cls, expression_type: type) -> type:
+        element_type: TypeAlias = get_list_type(  # type: ignore
+            get_optional_type(get_date_tagged_type(expression_type))
+        )
+        return List[element_type]
+
     def evaluate(self, *, table: SymbolTable, value: Any, attribute: str) -> None:
         """Adds the value to a set, although it actually is saved as a list
         since the final output is a JSON."""
         if isinstance(value, DateTaggedValue):
-            value = value.value
+            value = value.value  # type: ignore
 
-        cur_set = table.get(attribute)
+        cur_set = table.get(attribute)  # type: ignore
         cur_set = set(cur_set) if cur_set else set()
 
         if isinstance(value, (list, set)):
@@ -101,6 +147,13 @@ class SetOperation(Operation):
 
 class SortedListOperation(Operation):
     LABEL = "sortedlist"
+
+    @classmethod
+    def attribute_type(cls, expression_type: type) -> type:
+        element_type: TypeAlias = get_list_type(  # type: ignore
+            get_optional_type(get_date_tagged_type(expression_type))
+        )
+        return List[element_type]
 
     def evaluate(self, *, table: SymbolTable, value: Any, attribute: str) -> None:
         """Adds the value to a sorted list."""
@@ -124,7 +177,19 @@ class DateOperation(Operation):
         """Returns the comparison for this object."""
         raise OperationError(f"Unknown date operation: {self.LABEL}")
 
-    def evaluate(self, *, table: SymbolTable, value: Any, attribute: str) -> None:
+    @classmethod
+    def attribute_type(cls, expression_type: type) -> type:
+        temp_type = get_optional_type(expression_type)
+        if hasattr(temp_type, "__pydantic_generic_metadata__"):
+            origin = temp_type.__pydantic_generic_metadata__["origin"]  # type: ignore
+            if origin is DateTaggedValue:
+                return temp_type
+
+        return NoAssignment
+
+    def evaluate(
+        self, *, table: SymbolTable, value: DateTaggedValue[Any] | Any, attribute: str
+    ) -> None:
         """Compares dates to determine the result."""
         if value is None:
             return
@@ -171,6 +236,19 @@ class ComparisonOperation(Operation):
         """Returns the comparison for this object."""
         raise OperationError(f"Unknown comparison operation: {self.LABEL}")
 
+    @classmethod
+    def attribute_type(cls, expression_type: type) -> type:
+        temp_type = get_optional_type(expression_type)
+        if hasattr(temp_type, "__pydantic_generic_metadata__"):
+            origin = temp_type.__pydantic_generic_metadata__["origin"]  # type: ignore
+            if origin is DateTaggedValue:
+                args = temp_type.__pydantic_generic_metadata__[  # type: ignore
+                    "args"
+                ]  # type: ignore
+                return args[0]  # type: ignore
+
+        return temp_type
+
     def evaluate(self, *, table: SymbolTable, value: Any, attribute: str) -> None:
         """Does a comparison between the value and location value."""
         dest_value = table.get(attribute)
@@ -194,6 +272,10 @@ class ComparisonOperation(Operation):
 
 class MinOperation(ComparisonOperation):
     LABEL = "min"
+
+    @classmethod
+    def attribute_type(cls, expression_type: type) -> type:
+        return super().attribute_type(expression_type)
 
     def compare(self, left_value, right_value):
         return left_value < right_value

--- a/nacc_attribute_deriver/symbol_table.py
+++ b/nacc_attribute_deriver/symbol_table.py
@@ -2,13 +2,15 @@ from collections import deque
 from typing import Any, Dict, Iterator, MutableMapping, Optional
 
 
-class SymbolTable(MutableMapping):
+class SymbolTable(MutableMapping[str, Any]):
     """Implements a dictionary like object for using metadata paths as keys."""
 
     def __init__(
-        self, symbol_dict: Optional[MutableMapping] = None, separator: str = "."
+        self,
+        symbol_dict: Optional[MutableMapping[str, Any]] = None,
+        separator: str = ".",
     ) -> None:
-        self.__table: Dict[Any, Any] = {}
+        self.__table: Dict[str, Any] = {}
         self.__separator = separator
 
         # interpret metadata paths
@@ -21,7 +23,7 @@ class SymbolTable(MutableMapping):
         key_list = deque(key.split(self.__separator))
         while key_list:
             sub_key = key_list.popleft()
-            obj = table.get(sub_key)
+            obj = table.get(sub_key, None)
             if not obj:
                 if not key_list:
                     table[sub_key] = value
@@ -76,7 +78,7 @@ class SymbolTable(MutableMapping):
     def __delitem__(self, key: Any) -> None:
         return
 
-    def __iter__(self) -> Iterator:
+    def __iter__(self) -> Iterator[str]:
         return self.__table.__iter__()
 
     def __len__(self) -> int:
@@ -91,5 +93,5 @@ class SymbolTable(MutableMapping):
 
         return self.to_dict() == other.to_dict()
 
-    def to_dict(self) -> MutableMapping:
+    def to_dict(self) -> MutableMapping[str, Any]:
         return self.__table

--- a/rule_reflection/BUILD
+++ b/rule_reflection/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/rule_reflection/inspect_rule_types.py
+++ b/rule_reflection/inspect_rule_types.py
@@ -1,0 +1,82 @@
+from csv import DictReader
+from importlib import resources
+from inspect import signature
+from typing import Union, get_args, get_origin
+
+from pydantic import ValidationError
+
+from nacc_attribute_deriver import config
+from nacc_attribute_deriver.attributes.attribute_collection import (
+    AttributeCollectionRegistry,
+)
+from nacc_attribute_deriver.schema.schema import RuleFileModel
+
+
+def type_string(type_object: type) -> str:
+    if type_object is type(None):
+        return "None"
+
+    if hasattr(type_object, "__pydantic_generic_metadata__"):
+        origin = type_object.__pydantic_generic_metadata__["origin"]  # type: ignore
+        args = type_object.__pydantic_generic_metadata__["args"]  # type: ignore
+    else:
+        origin = get_origin(type_object)
+        args = get_args(type_object)
+
+    if not origin:
+        return type_object.__name__
+
+    if origin is Union and type(None) in args:
+        str_args = [type_string(arg) for arg in args if arg is not type(None)]  # type: ignore
+        return f"Optional[{', '.join(str_args)}]"
+
+    str_args = [type_string(arg) for arg in args]  # type: ignore
+    return f"{origin.__name__}[{', '.join(str_args)}]"  # type: ignore
+
+
+class TypeWrapper:
+    def __init__(self, wrapped_type: type) -> None:
+        self.wrapped_type = wrapped_type
+
+    def __str__(self) -> str:
+        return type_string(self.wrapped_type)
+
+    def is_optional(self) -> bool:
+        return get_origin(self.wrapped_type) is Union and type(None) in get_args(
+            self.wrapped_type
+        )
+
+
+def main():
+    instance_collections = AttributeCollectionRegistry.get_attribute_methods()
+    rules_file = resources.files(config).joinpath("curation_rules.csv")
+    with rules_file.open("r") as file_stream:
+        reader = DictReader(file_stream)
+        if not reader.fieldnames:
+            print("whoa. no fieldnames")
+
+        print("attribute,attribute_type,operation,expression,expression_type")
+        for row in reader:
+            try:
+                rule_schema = RuleFileModel.model_validate(row)
+            except ValidationError as error:
+                print(error)
+                continue
+
+            # location, operation, type
+            expression = instance_collections.get(f"create_{rule_schema.function}")
+            if not expression:
+                continue
+            sig = signature(expression.function)
+            return_type = sig.return_annotation
+            expression_type = TypeWrapper(return_type)
+            operation = rule_schema.assignment.operation
+            attribute_type = TypeWrapper(operation.attribute_type(return_type))
+
+            print(
+                f"{rule_schema.location},{attribute_type},{rule_schema.operation},{rule_schema.function},{expression_type}"
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/attributes/mqt/test_cognitive.py
+++ b/tests/attributes/mqt/test_cognitive.py
@@ -90,4 +90,4 @@ class TestCognitiveAttributeCollection:
 
         table["file.info.forms.json.cdrglob"] = None
         attr = CognitiveAttributeCollection.create(table)
-        assert attr._create_global_cdr().value is None
+        assert attr._create_global_cdr() is None

--- a/tests/attributes/mqt/test_demographics.py
+++ b/tests/attributes/mqt/test_demographics.py
@@ -78,7 +78,7 @@ class TestDemographicsAttributeCollection:
 
         # none case
         table["file.info.forms.json.educ"] = None
-        assert attr._create_uds_education_level().value is None
+        assert attr._create_uds_education_level() is None
 
 
 class TestDerivedDemographicsAttributeCollection:

--- a/tests/attributes/mqt/test_scan.py
+++ b/tests/attributes/mqt/test_scan.py
@@ -1,5 +1,6 @@
 """Tests deriving MQT SCAN variables."""
 
+from typing import Any, Dict
 import pytest
 from nacc_attribute_deriver.attributes.base.scan_namespace import SCANNamespace
 from nacc_attribute_deriver.attributes.mqt.scan import (
@@ -13,7 +14,7 @@ from nacc_attribute_deriver.symbol_table import SymbolTable
 @pytest.fixture(scope="function")
 def scan_mri_qc_table() -> SymbolTable:
     """Create dummy data for a SCAN MRI QC-focused curation."""
-    data = {
+    data: Dict[str, Any] = {
         "file": {"info": {"raw": {"series_type": "T1w", "study_date": "2025-01-01"}}},
         "subject": {
             "info": {
@@ -36,44 +37,46 @@ def scan_mri_qc_table() -> SymbolTable:
 class TestSCANMRIQCAttribute:
     """From scan_mridashboard.csv."""
 
-    def test_create_scan_mri_scan_types(self, scan_mri_qc_table):
+    def test_create_scan_mri_scan_types(self, scan_mri_qc_table: SymbolTable):
         """Tests _create_scan_mri_scan_types, which should just return the
         series_type."""
         attr = MQTSCANAttributeCollection.create(scan_mri_qc_table)
-        assert attr._create_scan_mri_scan_types() == "T1w"
+        assert attr  # type:ignore
+        assert attr._create_scan_mri_scan_types() == "T1w"  # type: ignore # type:ignore
 
         # empty
         scan_mri_qc_table["file.info.raw.series_type"] = None
         attr = MQTSCANAttributeCollection.create(scan_mri_qc_table)
-        assert attr._create_scan_mri_scan_types() is None
+        assert attr  # type:ignore
+        assert attr._create_scan_mri_scan_types() is None  # type: ignore # type:ignore
 
-    def test_create_scan_mri_session_count(self, scan_mri_qc_table):
+    def test_create_scan_mri_session_count(self, scan_mri_qc_table: SymbolTable):
         """Tests _create_scan_mri_session_count, which should just count scan-
         mri-dates."""
         attr = MQTSCANAttributeCollection.create(scan_mri_qc_table)
-        assert attr._create_scan_mri_session_count() == 5
+        assert attr._create_scan_mri_session_count() == 5  # type: ignore # type:ignore
 
         # empty
         scan_mri_qc_table["subject.info.derived.scan-mri-dates"] = []
         attr = MQTSCANAttributeCollection.create(scan_mri_qc_table)
-        assert attr._create_scan_mri_session_count() == 0
+        assert attr._create_scan_mri_session_count() == 0  # type: ignore # type:ignore
 
-    def test_create_scan_mri_year_count(self, scan_mri_qc_table):
+    def test_create_scan_mri_year_count(self, scan_mri_qc_table: SymbolTable):
         """Tests _create_scan_mri_year_count, which should just count the
         unique years in scan-mri-dates."""
         attr = MQTSCANAttributeCollection.create(scan_mri_qc_table)
-        assert attr._create_scan_mri_year_count() == 3
+        assert attr._create_scan_mri_year_count() == 3  # type: ignore # type:ignore
 
         # empty
         scan_mri_qc_table["subject.info.derived.scan-mri-dates"] = []
         attr = MQTSCANAttributeCollection.create(scan_mri_qc_table)
-        assert attr._create_scan_mri_year_count() == 0
+        assert attr._create_scan_mri_year_count() == 0  # type: ignore # type:ignore
 
 
 @pytest.fixture(scope="function")
 def scan_pet_qc_table() -> SymbolTable:
     """Create dummy data for a SCAN PET QC-focused curation."""
-    data = {
+    data: Dict[str, Any] = {
         "file": {"info": {"raw": {"radiotracer": 1, "scan_date": "2025-01-01"}}},
         "subject": {"info": {"derived": {"scan-pet-dates": ["2000-12-12"]}}},
     }
@@ -84,48 +87,49 @@ def scan_pet_qc_table() -> SymbolTable:
 class TestSCANPETQCAttribute:
     """From scan_petdashboard.csv."""
 
-    def test_create_scan_pet_scan_types(self, scan_pet_qc_table):
+    def test_create_scan_pet_scan_types(self, scan_pet_qc_table: SymbolTable):
         """Tests _create_scan_pet_scan_types, loop over all options."""
         for k, v in SCANNamespace.TRACER_SCAN_TYPE_MAPPING.items():
             # convert to string just to make sure type conversion is correct
             scan_pet_qc_table["file.info.raw.radiotracer"] = str(k)
             attr = MQTSCANAttributeCollection.create(scan_pet_qc_table)
-            assert attr._create_scan_pet_scan_types() == v
+            assert attr._create_scan_pet_scan_types() == v  # type: ignore # type:ignore
 
             # string float case
             scan_pet_qc_table["file.info.raw.radiotracer"] = str(float(k))
             attr = MQTSCANAttributeCollection.create(scan_pet_qc_table)
-            assert attr._create_scan_pet_scan_types() == v
+            assert attr._create_scan_pet_scan_types() == v  # type: ignore # type:ignore
 
         # None case
         scan_pet_qc_table["file.info.raw.radiotracer"] = ""
         attr = MQTSCANAttributeCollection.create(scan_pet_qc_table)
-        assert attr._create_scan_pet_scan_types() is None
+        assert attr._create_scan_pet_scan_types() is None  # type: ignore # type:ignore
 
-    def test_create_scan_pet_session_count(self, scan_pet_qc_table):
+    def test_create_scan_pet_session_count(self, scan_pet_qc_table: SymbolTable):
         """Tests _create_scan_pet_session_count, which should just count scan-
         pet-dates."""
+        assert scan_pet_qc_table.get("subject.info.derived.scan-pet-dates")  # type:ignore
         attr = MQTSCANAttributeCollection.create(scan_pet_qc_table)
-        assert attr._create_scan_pet_session_count() == 1
+        assert attr._create_scan_pet_session_count() == 1  # type: ignore # type:ignore
 
         # empty
         scan_pet_qc_table["subject.info.derived.scan-pet-dates"] = []
         attr = MQTSCANAttributeCollection.create(scan_pet_qc_table)
-        assert attr._create_scan_pet_session_count() == 0
+        assert attr._create_scan_pet_session_count() == 0  # type: ignore # type:ignore
 
-    def test_create_scan_pet_year_count(self, scan_pet_qc_table):
+    def test_create_scan_pet_year_count(self, scan_pet_qc_table: SymbolTable):
         """Tests _create_scan_pet_year_count, which should just count the
         unique years in scan-pet-dates."""
         attr = MQTSCANAttributeCollection.create(scan_pet_qc_table)
-        assert attr._create_scan_pet_year_count() == 1
+        assert attr._create_scan_pet_year_count() == 1  # type: ignore # type:ignore
 
         # empty
         scan_pet_qc_table["subject.info.derived.scan-pet-dates"] = []
-        assert attr._create_scan_pet_year_count() == 0
+        assert attr._create_scan_pet_year_count() == 0  # type:ignore
 
-    def test_create_scan_pet_amyloid_tracers(self, scan_pet_qc_table):
+    def test_create_scan_pet_amyloid_tracers(self, scan_pet_qc_table: SymbolTable):
         """Tests _create_scan_pet_amyloid_tracers, loop over all options."""
-        attr = scan_pet_qc_table
+
         for k, v in SCANNamespace.TRACER_MAPPING.items():
             # convert to string just to make sure type conversion is correct
             scan_pet_qc_table["file.info.raw.radiotracer"] = str(k)
@@ -133,29 +137,29 @@ class TestSCANPETQCAttribute:
 
             # needs to == amyloid
             if k in [2, 3, 4, 5]:
-                assert attr._create_scan_pet_amyloid_tracers() == v
+                assert attr._create_scan_pet_amyloid_tracers() == v  # type:ignore
             else:
-                assert attr._create_scan_pet_amyloid_tracers() is None
+                assert attr._create_scan_pet_amyloid_tracers() is None  # type:ignore # type:ignore
 
         # None case
         scan_pet_qc_table["file.info.raw.radiotracer"] = None
         attr = MQTSCANAttributeCollection.create(scan_pet_qc_table)
-        assert attr._create_scan_pet_amyloid_tracers() is None
+        assert attr._create_scan_pet_amyloid_tracers() is None  # type:ignore
 
-    def test_create_scan_pet_tau_tracers(self, scan_pet_qc_table):
+    def test_create_scan_pet_tau_tracers(self, scan_pet_qc_table: SymbolTable):
         """Tests _create_scan_pet_tau_tracers, which just checks if scan_type.
 
         == tau and returns tracer string if so.
         """
         attr = MQTSCANAttributeCollection.create(scan_pet_qc_table)
-        assert attr._create_scan_pet_tau_tracers() is None
+        assert attr._create_scan_pet_tau_tracers() is None  # type:ignore
 
         # tau scans
         for i in [6, 7, 8, 9]:
             scan_pet_qc_table["file.info.raw.radiotracer"] = i
             attr = MQTSCANAttributeCollection.create(scan_pet_qc_table)
             assert (
-                attr._create_scan_pet_tau_tracers() == SCANNamespace.TRACER_MAPPING[i]
+                attr._create_scan_pet_tau_tracers() == SCANNamespace.TRACER_MAPPING[i]  # type:ignore
             )
 
 
@@ -176,52 +180,52 @@ def scan_mri_sbm() -> SymbolTable:
 class TestSCANMRISBMAttribute:
     """From ucbmrisbm.csv."""
 
-    def test_create_scan_volume_analysis_indicator(self, scan_mri_sbm):
+    def test_create_scan_volume_analysis_indicator(self, scan_mri_sbm: SymbolTable):
         """Tests _create_scan_volume_analysis_indicator, which looks at
         cerebrumtcv when series_type == T1w."""
         attr = MQTSCANAttributeCollection.create(scan_mri_sbm)
-        assert attr._create_scan_volume_analysis_indicator()
+        assert attr._create_scan_volume_analysis_indicator()  # type:ignore
 
         # 0 case, is a valid number so should return True
         scan_mri_sbm["file.info.raw.cerebrumtcv"] = "0"
         attr = MQTSCANAttributeCollection.create(scan_mri_sbm)
-        assert attr._create_scan_volume_analysis_indicator()
+        assert attr._create_scan_volume_analysis_indicator()  # type:ignore
 
         # empty
         scan_mri_sbm["file.info.raw.cerebrumtcv"] = None
         attr = MQTSCANAttributeCollection.create(scan_mri_sbm)
-        assert not attr._create_scan_volume_analysis_indicator()
+        assert not attr._create_scan_volume_analysis_indicator()  # type:ignore
 
-    def test_create_scan_flair_wmh_indicator(self, scan_mri_sbm):
+    def test_create_scan_flair_wmh_indicator(self, scan_mri_sbm: SymbolTable):
         """Tests _create_scan_flair_wmh_indicator, which looks at wmh."""
         attr = MQTSCANAttributeCollection.create(scan_mri_sbm)
-        assert attr._create_scan_flair_wmh_indicator()
+        assert attr._create_scan_flair_wmh_indicator()  # type:ignore
 
         # 0 case, is a valid number so should return True
         scan_mri_sbm["file.info.raw.wmh"] = "0"
         attr = MQTSCANAttributeCollection.create(scan_mri_sbm)
-        assert attr._create_scan_flair_wmh_indicator()
+        assert attr._create_scan_flair_wmh_indicator()  # type:ignore
 
         # empty
         scan_mri_sbm["file.info.raw.wmh"] = None
         attr = MQTSCANAttributeCollection.create(scan_mri_sbm)
-        assert not attr._create_scan_flair_wmh_indicator()
+        assert not attr._create_scan_flair_wmh_indicator()  # type:ignore
 
-    def test_create_mri_scan_analysis_types(self, scan_mri_sbm):
+    def test_create_mri_scan_analysis_types(self, scan_mri_sbm: SymbolTable):
         """Tests _create_mri_scan_analysis_types."""
         attr = MQTSCANAttributeCollection.create(scan_mri_sbm)
-        assert attr._create_mri_scan_analysis_types() == [
+        assert attr._create_mri_scan_analysis_types() == [  # type:ignore
             MRIAnalysisTypes.T1_VOLUME,
             MRIAnalysisTypes.FLAIR_WMH,
         ]
 
         # t1 volume is missing
         scan_mri_sbm["file.info.raw.cerebrumtcv"] = None
-        assert attr._create_mri_scan_analysis_types() == [MRIAnalysisTypes.FLAIR_WMH]
+        assert attr._create_mri_scan_analysis_types() == [MRIAnalysisTypes.FLAIR_WMH]  # type:ignore
 
         # both are missing
         scan_mri_sbm["file.info.raw.wmh"] = None
-        assert attr._create_mri_scan_analysis_types() is None
+        assert attr._create_mri_scan_analysis_types() is None  # type:ignore
 
 
 @pytest.fixture(scope="function")
@@ -248,89 +252,92 @@ def scan_pet_amyloid_gaain() -> SymbolTable:
 class TestSCANAmyloidPETGAAINAttribute:
     """From v_berkeley_amyloid_pet_gaain.csv."""
 
-    def test_create_scan_pet_centaloid(self, scan_pet_amyloid_gaain):
+    def test_create_scan_pet_centaloid(self, scan_pet_amyloid_gaain: SymbolTable):
         """Tests _create_scan_pet_centaloid, should just return centaloid as a
         float."""
         attr = MQTSCANAttributeCollection.create(scan_pet_amyloid_gaain)
-        assert attr._create_scan_pet_centaloid() == 1.5
+        assert attr._create_scan_pet_centaloid() == 1.5  # type:ignore
 
         # empty
         scan_pet_amyloid_gaain["file.info.raw.centiloids"] = None
         attr = MQTSCANAttributeCollection.create(scan_pet_amyloid_gaain)
-        assert attr._create_scan_pet_centaloid() is None
+        assert attr._create_scan_pet_centaloid() is None  # type:ignore
 
-    def test_create_scan_pet_centaloid_x(self, scan_pet_amyloid_gaain):
+    def test_create_scan_pet_centaloid_x(self, scan_pet_amyloid_gaain: SymbolTable):
         """Tests _create_scan_pet_centaloid_*, should return centerloid as a
         float if the tracer is the given value."""
-        attr = scan_pet_amyloid_gaain
         scan_pet_amyloid_gaain["file.info.raw.tracer"] = "2"
         attr = MQTSCANAttributeCollection.create(scan_pet_amyloid_gaain)
-        assert attr._create_scan_pet_centaloid_pib() == 1.5
+        assert attr._create_scan_pet_centaloid_pib() == 1.5  # type:ignore
 
         scan_pet_amyloid_gaain["file.info.raw.tracer"] = "3.0"
         attr = MQTSCANAttributeCollection.create(scan_pet_amyloid_gaain)
-        assert attr._create_scan_pet_centaloid_florbetapir() == 1.5
+        assert attr._create_scan_pet_centaloid_florbetapir() == 1.5  # type:ignore
 
         scan_pet_amyloid_gaain["file.info.raw.tracer"] = "4"
         attr = MQTSCANAttributeCollection.create(scan_pet_amyloid_gaain)
-        assert attr._create_scan_pet_centaloid_florbetaben() == 1.5
+        assert attr._create_scan_pet_centaloid_florbetaben() == 1.5  # type:ignore
 
         scan_pet_amyloid_gaain["file.info.raw.tracer"] = "5"
         attr = MQTSCANAttributeCollection.create(scan_pet_amyloid_gaain)
-        assert attr._create_scan_pet_centaloid_nav4694() == 1.5
+        assert attr._create_scan_pet_centaloid_nav4694() == 1.5  # type:ignore
 
         # 99, should all be None
         scan_pet_amyloid_gaain["file.info.raw.tracer"] = "99"
         attr = MQTSCANAttributeCollection.create(scan_pet_amyloid_gaain)
-        assert attr._create_scan_pet_centaloid_pib() is None
-        assert attr._create_scan_pet_centaloid_florbetapir() is None
-        assert attr._create_scan_pet_centaloid_florbetaben() is None
-        assert attr._create_scan_pet_centaloid_nav4694() is None
+        assert attr._create_scan_pet_centaloid_pib() is None  # type:ignore
+        assert attr._create_scan_pet_centaloid_florbetapir() is None  # type:ignore
+        assert attr._create_scan_pet_centaloid_florbetaben() is None  # type:ignore
+        assert attr._create_scan_pet_centaloid_nav4694() is None  # type:ignore
 
-    def test_create_scan_pet_amyloid_positivity_indicator(self, scan_pet_amyloid_gaain):
+    def test_create_scan_pet_amyloid_positivity_indicator(
+        self, scan_pet_amyloid_gaain: SymbolTable
+    ):
         """Tests _create_scan_pet_amyloid_positivity_indicator, which just gets
         amyloid_status."""
         attr = MQTSCANAttributeCollection.create(scan_pet_amyloid_gaain)
-        assert attr._create_scan_pet_amyloid_positivity_indicator()
+        assert attr._create_scan_pet_amyloid_positivity_indicator()  # type:ignore
 
         # string float case
         scan_pet_amyloid_gaain["file.info.raw.amyloid_status"] = "1.0"
         attr = MQTSCANAttributeCollection.create(scan_pet_amyloid_gaain)
-        assert attr._create_scan_pet_amyloid_positivity_indicator()
+        assert attr._create_scan_pet_amyloid_positivity_indicator()  # type:ignore
 
         # 0 case, should be False
         scan_pet_amyloid_gaain["file.info.raw.amyloid_status"] = "0"
         attr = MQTSCANAttributeCollection.create(scan_pet_amyloid_gaain)
-        assert not attr._create_scan_pet_amyloid_positivity_indicator()
+        assert not attr._create_scan_pet_amyloid_positivity_indicator()  # type:ignore
 
         # empty
         scan_pet_amyloid_gaain["file.info.raw.amyloid_status"] = None
         attr = MQTSCANAttributeCollection.create(scan_pet_amyloid_gaain)
-        assert not attr._create_scan_pet_amyloid_positivity_indicator()
+        assert not attr._create_scan_pet_amyloid_positivity_indicator()  # type:ignore
 
-    def test_create_scan_pet_amyloid_gaain_analysis_type(self, scan_pet_amyloid_gaain):
+    def test_create_scan_pet_amyloid_gaain_analysis_type(
+        self, scan_pet_amyloid_gaain: SymbolTable
+    ):
         """Tests _create_scan_pet_amyloid_gaain_analysis_type."""
         attr = MQTSCANAttributeCollection.create(scan_pet_amyloid_gaain)
         assert (
-            attr._create_scan_pet_amyloid_gaain_analysis_type()
+            attr._create_scan_pet_amyloid_gaain_analysis_type()  # type:ignore
             == PETAnalysisTypes.AMYLOID_GAAIN
         )
 
         # missing centiloid
         scan_pet_amyloid_gaain["file.info.raw.centiloids"] = None
         attr = MQTSCANAttributeCollection.create(scan_pet_amyloid_gaain)
-        assert attr._create_scan_pet_amyloid_gaain_analysis_type() is None
+        assert attr._create_scan_pet_amyloid_gaain_analysis_type() is None  # type:ignore
 
         # missing gaain_summary_suvr
         scan_pet_amyloid_gaain["file.info.raw.centiloids"] = "1.234"
         scan_pet_amyloid_gaain["file.info.raw.gaain_summary_suvr"] = None
         attr = MQTSCANAttributeCollection.create(scan_pet_amyloid_gaain)
-        assert attr._create_scan_pet_amyloid_gaain_analysis_type() is None
+        assert attr._create_scan_pet_amyloid_gaain_analysis_type() is None  # type:ignore
 
         # empty
         scan_pet_amyloid_gaain["file.info.raw.centiloids"] = None
         attr = MQTSCANAttributeCollection.create(scan_pet_amyloid_gaain)
-        assert attr._create_scan_pet_amyloid_gaain_analysis_type() is None
+        assert attr._create_scan_pet_amyloid_gaain_analysis_type() is None  # type:ignore
 
 
 @pytest.fixture(scope="function")
@@ -349,18 +356,20 @@ def scan_pet_amyloid_npdka() -> SymbolTable:
 class TestSCANAmyloidPETNPDKAAttribute:
     """From v_ucberkeley_amyloid_mrifree_npdka.csv."""
 
-    def test_create_scan_pet_amyloid_npdka_analysis_type(self, scan_pet_amyloid_npdka):
+    def test_create_scan_pet_amyloid_npdka_analysis_type(
+        self, scan_pet_amyloid_npdka: SymbolTable
+    ):
         """Tests _create_scan_pet_amyloid_npdka_analysis_type."""
         attr = MQTSCANAttributeCollection.create(scan_pet_amyloid_npdka)
         assert (
-            attr._create_scan_pet_amyloid_npdka_analysis_type()
+            attr._create_scan_pet_amyloid_npdka_analysis_type()  # type:ignore
             == PETAnalysisTypes.AMYLOID_NPDKA
         )
 
         # missing
         scan_pet_amyloid_npdka["file.info.raw.npdka_summary_suvr"] = None
         attr = MQTSCANAttributeCollection.create(scan_pet_amyloid_npdka)
-        assert attr._create_scan_pet_amyloid_npdka_analysis_type() is None
+        assert attr._create_scan_pet_amyloid_npdka_analysis_type() is None  # type:ignore
 
 
 @pytest.fixture(scope="function")
@@ -379,18 +388,20 @@ def scan_pet_fdg_npdka() -> SymbolTable:
 class TestSCANFDGPETNPDKAAttribute:
     """From v_ucberkeley_fdg_metaroi_npdka.csv."""
 
-    def test_create_scan_pet_fdg_npdka_analysis_type(self, scan_pet_fdg_npdka):
+    def test_create_scan_pet_fdg_npdka_analysis_type(
+        self, scan_pet_fdg_npdka: SymbolTable
+    ):
         """Tests _create_scan_pet_fdg_npdka_analysis_type."""
         attr = MQTSCANAttributeCollection.create(scan_pet_fdg_npdka)
         assert (
-            attr._create_scan_pet_fdg_npdka_analysis_type()
+            attr._create_scan_pet_fdg_npdka_analysis_type()  # type:ignore
             == PETAnalysisTypes.FDG_NPDKA
         )
 
         # missing
         scan_pet_fdg_npdka["file.info.raw.fdg_metaroi_suvr"] = None
         attr = MQTSCANAttributeCollection.create(scan_pet_fdg_npdka)
-        assert attr._create_scan_pet_fdg_npdka_analysis_type() is None
+        assert attr._create_scan_pet_fdg_npdka_analysis_type() is None  # type:ignore
 
 
 @pytest.fixture(scope="function")
@@ -414,15 +425,17 @@ def scan_pet_tau_npdka() -> SymbolTable:
 class TestSCANTauPETNPDKAAttribute:
     """From v_ucberkeley_tau_mrifree_npdka.csv."""
 
-    def test_create_scan_pet_tau_npdka_analysis_type(self, scan_pet_tau_npdka):
+    def test_create_scan_pet_tau_npdka_analysis_type(
+        self, scan_pet_tau_npdka: SymbolTable
+    ):
         """Tests _create_scan_pet_tau_npdka_analysis_type."""
         attr = MQTSCANAttributeCollection.create(scan_pet_tau_npdka)
         assert (
-            attr._create_scan_pet_tau_npdka_analysis_type()
+            attr._create_scan_pet_tau_npdka_analysis_type()  # type:ignore
             == PETAnalysisTypes.TAU_NPDKA
         )
 
         # missing
         scan_pet_tau_npdka["file.info.raw.meta_temporal_suvr"] = None
         attr = MQTSCANAttributeCollection.create(scan_pet_tau_npdka)
-        assert attr._create_scan_pet_tau_npdka_analysis_type() is None
+        assert attr._create_scan_pet_tau_npdka_analysis_type() is None  # type:ignore

--- a/tests/attributes/nacc/genetics/test_ncrad.py
+++ b/tests/attributes/nacc/genetics/test_ncrad.py
@@ -5,6 +5,7 @@ from nacc_attribute_deriver.attributes.nacc.genetics.ncrad import (
     HistoricalNCRADAttributeCollection,
     NCRADAttributeCollection,
 )
+from nacc_attribute_deriver.schema.errors import InvalidFieldError
 from nacc_attribute_deriver.symbol_table import SymbolTable
 
 from tests.conftest import set_attribute
@@ -53,7 +54,12 @@ class TestHistoricalNCRADAttributeCollection:
 
         # invalid cases
         set_attribute(table, raw_prefix, "apoenp", None)
-        for invalid in [0, 7, None, ""]:
+        for invalid in [0, 7, None]:
             set_attribute(table, raw_prefix, "apoe", invalid)
             attr = HistoricalNCRADAttributeCollection.create(table)
             assert attr._create_historic_apoe() == 9
+
+        set_attribute(table, raw_prefix, "apoe", "invalid")
+        attr = HistoricalNCRADAttributeCollection.create(table)
+        with pytest.raises(InvalidFieldError):
+            attr._create_historic_apoe()

--- a/tests/attributes/nacc/genetics/test_niagads.py
+++ b/tests/attributes/nacc/genetics/test_niagads.py
@@ -32,4 +32,4 @@ class TestNIAGADSAttribute:
         assert attr._create_niagads_gwas() == 1
         assert attr._create_niagads_exome() == 1
         assert attr._create_niagads_wgs() == 0
-        assert attr._create_niagads_wes() == 0
+        assert attr._create_niagads_wes() is None

--- a/tests/attributes/nacc/modules/np/test_form_np.py
+++ b/tests/attributes/nacc/modules/np/test_form_np.py
@@ -48,7 +48,7 @@ def np_form_table() -> SymbolTable:
 class TestHelpers:
     def test_mapgross_null(self, np_form_table):
         np_form_nulls = NPFormAttributeCollection.create(np_form_table)
-        assert np_form_nulls._map_gross(None) is None
+        assert np_form_nulls._map_gross(None) == 9
 
     def test_mapsub4_null(self, np_form_table):
         np_form_nulls = NPFormAttributeCollection.create(np_form_table)
@@ -69,7 +69,7 @@ class TestHelpers:
 
     def test_maplewy_null(self, np_form_table):
         np_form_nulls = NPFormAttributeCollection.create(np_form_table)
-        assert np_form_nulls._map_lewy() is None
+        assert np_form_nulls._map_lewy() == 9
 
     def test_mapgross(self, np_form_attribute_table, form_prefix):
         np_form_attribute = NPFormAttributeCollection.create(np_form_attribute_table)

--- a/tests/general/test_e2e.py
+++ b/tests/general/test_e2e.py
@@ -166,7 +166,6 @@ def test_niagads_investigator():
     assert form["subject.info.derived"] == {
         "niagads_exome": 1,
         "niagads_gwas": 1,
-        "niagads_wes": 0,
         "niagads_wgs": 0,
     }
 


### PR DESCRIPTION
Makes two main changes:
1. Adds code to use reflection to identify the types assigned to attributes by the curation rules. Includes Operation.attribute_type methods that compute the type set by an Operation when applied to a value of another type. Also, includes a script that computes a table showing the attribute types.
2. Changes all of the expression functions so that Nones are consistently handled for missing values for attributes that do not have a numeric "missing" code.