### PR TITLE
Compute operation types

### DIFF
--- a/nacc_attribute_deriver/attribute_deriver.py
+++ b/nacc_attribute_deriver/attribute_deriver.py
@@ -103,7 +103,7 @@ class AttributeDeriver:
             value = method.apply(table)
             if value is None:
                 continue
-            if isinstance(value, DateTaggedValue) and value.value is None:
+            if isinstance(value, DateTaggedValue) and value.value is None:  # type: ignore
                 continue
 
             for assignment in rule.assignments:

--- a/nacc_attribute_deriver/attributes/attribute_collection.py
+++ b/nacc_attribute_deriver/attributes/attribute_collection.py
@@ -8,7 +8,7 @@ Heavily based off of
 import logging
 from inspect import isfunction
 from types import FunctionType
-from typing import Any, Callable, ClassVar, Dict, List, Optional, Union
+from typing import Any, Callable, ClassVar, Dict, List, Optional, Tuple, Union
 
 from pydantic import BaseModel, ConfigDict
 
@@ -49,12 +49,14 @@ class AttributeExpression(BaseModel):
 class AttributeCollectionRegistry(type):
     collection_types: ClassVar[List[type]] = []
 
-    def __init__(cls, name, bases, attrs):
+    def __init__(
+        cls, name: str, bases: Tuple[type], attrs: Dict[str, str | FunctionType]
+    ):
         """Registers the class in the registry when the class has this class as
         a metaclass."""
         if (
             name != "AttributeCollection"
-            and name not in AttributeCollectionRegistry.collection_types
+            and name not in AttributeCollectionRegistry.collection_types  # type: ignore
         ):
             AttributeCollectionRegistry.collection_types.append(cls)
 
@@ -68,11 +70,12 @@ class AttributeCollectionRegistry(type):
         Returns:
           a dictionary mapping a function name to the attribute expression
         """
-        methods = {}
+        methods: Dict[str, AttributeExpression] = {}
         for collection_type in cls.collection_types:
             for name, function in collection_type.get_all_hooks().items():  # type: ignore
                 methods[name] = AttributeExpression(
-                    function=function, attribute_class=collection_type
+                    function=function,  # type: ignore
+                    attribute_class=collection_type,
                 )
 
         return methods
@@ -102,7 +105,7 @@ class AttributeCollection(object, metaclass=AttributeCollectionRegistry):
     @classmethod
     def get_all_hooks(cls) -> Dict[str, FunctionType]:
         """Grab all available _create_ functions."""
-        result = {}
+        result: Dict[str, FunctionType] = {}
         for attr_name in dir(cls):
             attr = getattr(cls, attr_name)
             if isfunction(attr) and attr_name.startswith("_create_"):
@@ -111,7 +114,7 @@ class AttributeCollection(object, metaclass=AttributeCollectionRegistry):
         return result
 
     @classmethod
-    def get_derive_hook(cls, derive_name: str) -> Optional[Callable]:
+    def get_derive_hook(cls, derive_name: str) -> Optional[Callable[[], Any]]:
         """Aggregates all _create functions and returns the function if
         derive_name matches. Throws error otherwise.
 
@@ -132,7 +135,7 @@ class AttributeCollection(object, metaclass=AttributeCollectionRegistry):
         return None
 
     @staticmethod
-    def is_target_int(value: Union[int, str], target: int) -> bool:
+    def is_target_int(value: Union[int, str, None], target: int) -> bool:
         """Check whether the value is the specified target int. This might be
         overkill but wanted it to handle str/int comparisons.
 

--- a/nacc_attribute_deriver/schema/operation.py
+++ b/nacc_attribute_deriver/schema/operation.py
@@ -157,8 +157,8 @@ class SetOperation(Operation):
         if isinstance(value, DateTaggedValue):
             value = value.value  # type: ignore
 
-        cur_set = table.get(attribute)  # type: ignore
-        cur_set: Set[Any] = set(cur_set) if cur_set else set()
+        cur_set: Set[Any] = table.get(attribute)  # type: ignore
+        cur_set = set(cur_set) if cur_set else set()
 
         if isinstance(value, (list, set)):
             cur_set = cur_set.union(set(value))  # type: ignore
@@ -204,7 +204,7 @@ class DateOperation(Operation):
 
     @classmethod
     def attribute_type(cls, expression_type: type) -> type:
-        temp_type = get_date_tagged_type(get_optional_type(expression_type))
+        temp_type: TypeAlias = get_date_tagged_type(get_optional_type(expression_type))  # type: ignore
         if temp_type is not expression_type:
             return DateTaggedValue[temp_type]
 

--- a/nacc_attribute_deriver/schema/operation.py
+++ b/nacc_attribute_deriver/schema/operation.py
@@ -5,7 +5,18 @@ Uses a metaclass to keep track of operation types.
 
 from abc import abstractmethod
 from datetime import date
-from typing import Any, ClassVar, Dict, List, TypeAlias, Union, get_args, get_origin
+from types import FunctionType
+from typing import (
+    Any,
+    ClassVar,
+    Dict,
+    List,
+    Tuple,
+    TypeAlias,
+    Union,
+    get_args,
+    get_origin,
+)
 
 from nacc_attribute_deriver.attributes.base.namespace import DateTaggedValue
 from nacc_attribute_deriver.symbol_table import SymbolTable
@@ -49,13 +60,17 @@ class OperationError(Exception):
 class OperationRegistry(type):
     operations: ClassVar[Dict[str, type]] = {}
 
-    def __init__(cls, name, bases, attrs):
+    def __init__(
+        cls, name: str, bases: Tuple[type], attrs: Dict[str, str | FunctionType]
+    ):
+        """Registers the class in the registry when the class has this class as
+        a metaclass."""
         if (
             name != "OperationRegistry"
-            and cls.LABEL is not None
+            and cls.LABEL is not None  # type: ignore
             and name not in OperationRegistry.operations
         ):
-            OperationRegistry.operations[cls.LABEL] = cls
+            OperationRegistry.operations[cls.LABEL] = cls  # type: ignore
 
 
 class Operation(object, metaclass=OperationRegistry):
@@ -198,7 +213,7 @@ class DateOperation(Operation):
                 f"Unable to perform {self.LABEL} operation without date"
             )
 
-        if value.value is None:
+        if value.value is None:  # type: ignore
             return
 
         if self.LABEL not in ["initial", "latest"]:

--- a/nacc_attribute_deriver/schema/operation.py
+++ b/nacc_attribute_deriver/schema/operation.py
@@ -161,7 +161,7 @@ class SetOperation(Operation):
         cur_set: Set[Any] = set(cur_set) if cur_set else set()
 
         if isinstance(value, (list, set)):
-            cur_set = cur_set.union(set(value)) # type: ignore
+            cur_set = cur_set.union(set(value))  # type: ignore
         elif value is not None:
             cur_set.add(value)
 
@@ -280,7 +280,7 @@ class ComparisonOperation(Operation):
             raise OperationError(f"Unknown comparison operation: {self.LABEL}")
 
         if isinstance(value, DateTaggedValue):
-            value = value.value # type: ignore
+            value = value.value  # type: ignore
         if value is None:
             return
 

--- a/nacc_attribute_deriver/schema/operation.py
+++ b/nacc_attribute_deriver/schema/operation.py
@@ -1,16 +1,45 @@
-"""Defines the operations to be performed on derived variables. Uses a
-metaclass to keep track of operation types.
+"""Defines the operations to be performed on derived variables.
 
-This kind of feels overengineered?
+Uses a metaclass to keep track of operation types.
 """
 
 from abc import abstractmethod
 from datetime import date
-from typing import Any, ClassVar, Dict
+from typing import Any, ClassVar, Dict, List, TypeAlias, Union, get_args, get_origin
 
 from nacc_attribute_deriver.attributes.base.namespace import DateTaggedValue
 from nacc_attribute_deriver.symbol_table import SymbolTable
 from nacc_attribute_deriver.utils.date import datetime_from_form_date
+
+
+class NoAssignment:
+    pass
+
+
+def get_optional_type(expression_type: type) -> type:
+    origin = get_origin(expression_type)
+    args = get_args(expression_type)
+    if origin is Union and type(None) in args:
+        return args[0]
+    return expression_type
+
+
+def get_list_type(expression_type: type) -> type:
+    origin = get_origin(expression_type)
+    if origin is list:
+        return get_args(expression_type)[0]
+    return expression_type
+
+
+def get_date_tagged_type(expression_type: type) -> type:
+    if hasattr(expression_type, "__pydantic_generic_metadata__"):
+        origin = expression_type.__pydantic_generic_metadata__["origin"]  # type: ignore
+        if origin is DateTaggedValue:
+            args = expression_type.__pydantic_generic_metadata__[  # type: ignore
+                "args"
+            ]  # type: ignore
+            return args[0]  # type: ignore
+    return expression_type
 
 
 class OperationError(Exception):
@@ -31,6 +60,11 @@ class OperationRegistry(type):
 
 class Operation(object, metaclass=OperationRegistry):
     LABEL: str | None = None
+
+    @classmethod
+    def attribute_type(cls, expression_type: type) -> type:
+        """Returns the type assigned to the attribute by this operation."""
+        return NoAssignment
 
     @classmethod
     def create(cls, label: str) -> "Operation":
@@ -62,13 +96,17 @@ class Operation(object, metaclass=OperationRegistry):
 class UpdateOperation(Operation):
     LABEL = "update"
 
+    @classmethod
+    def attribute_type(cls, expression_type: type) -> type:
+        return get_date_tagged_type(get_optional_type(expression_type))
+
     def evaluate(  # type: ignore
         self, *, table: SymbolTable, value: Any, attribute: str
     ) -> None:
         """Simply updates the location."""
 
         if isinstance(value, DateTaggedValue):
-            value = value.value
+            value = value.value  # type: ignore
         if value is None:
             return
 
@@ -81,13 +119,20 @@ class UpdateOperation(Operation):
 class SetOperation(Operation):
     LABEL = "set"
 
+    @classmethod
+    def attribute_type(cls, expression_type: type) -> type:
+        element_type: TypeAlias = get_list_type(  # type: ignore
+            get_date_tagged_type(get_optional_type(expression_type))
+        )
+        return List[element_type]
+
     def evaluate(self, *, table: SymbolTable, value: Any, attribute: str) -> None:
         """Adds the value to a set, although it actually is saved as a list
         since the final output is a JSON."""
         if isinstance(value, DateTaggedValue):
-            value = value.value
+            value = value.value  # type: ignore
 
-        cur_set = table.get(attribute)
+        cur_set = table.get(attribute)  # type: ignore
         cur_set = set(cur_set) if cur_set else set()
 
         if isinstance(value, (list, set)):
@@ -102,14 +147,21 @@ class SetOperation(Operation):
 class SortedListOperation(Operation):
     LABEL = "sortedlist"
 
+    @classmethod
+    def attribute_type(cls, expression_type: type) -> type:
+        element_type: TypeAlias = get_list_type(  # type: ignore
+            get_date_tagged_type(get_optional_type(expression_type))
+        )
+        return List[element_type]
+
     def evaluate(self, *, table: SymbolTable, value: Any, attribute: str) -> None:
         """Adds the value to a sorted list."""
         if isinstance(value, DateTaggedValue):
-            value = value.value
+            value = value.value  # type: ignore
 
         cur_list = table.get(attribute, [])
         if isinstance(value, (list, set)):
-            cur_list.extend(list(value))
+            cur_list.extend(list(value))  # type: ignore
         elif value is not None:
             cur_list.append(value)
 
@@ -124,7 +176,19 @@ class DateOperation(Operation):
         """Returns the comparison for this object."""
         raise OperationError(f"Unknown date operation: {self.LABEL}")
 
-    def evaluate(self, *, table: SymbolTable, value: Any, attribute: str) -> None:
+    @classmethod
+    def attribute_type(cls, expression_type: type) -> type:
+        temp_type = get_optional_type(expression_type)
+        if hasattr(temp_type, "__pydantic_generic_metadata__"):
+            origin = temp_type.__pydantic_generic_metadata__["origin"]  # type: ignore
+            if origin is DateTaggedValue:
+                return temp_type
+
+        return NoAssignment
+
+    def evaluate(
+        self, *, table: SymbolTable, value: DateTaggedValue[Any] | Any, attribute: str
+    ) -> None:
         """Compares dates to determine the result."""
         if value is None:
             return
@@ -171,6 +235,19 @@ class ComparisonOperation(Operation):
         """Returns the comparison for this object."""
         raise OperationError(f"Unknown comparison operation: {self.LABEL}")
 
+    @classmethod
+    def attribute_type(cls, expression_type: type) -> type:
+        temp_type = get_optional_type(expression_type)
+        if hasattr(temp_type, "__pydantic_generic_metadata__"):
+            origin = temp_type.__pydantic_generic_metadata__["origin"]  # type: ignore
+            if origin is DateTaggedValue:
+                args = temp_type.__pydantic_generic_metadata__[  # type: ignore
+                    "args"
+                ]  # type: ignore
+                return args[0]  # type: ignore
+
+        return temp_type
+
     def evaluate(self, *, table: SymbolTable, value: Any, attribute: str) -> None:
         """Does a comparison between the value and location value."""
         dest_value = table.get(attribute)
@@ -194,6 +271,10 @@ class ComparisonOperation(Operation):
 
 class MinOperation(ComparisonOperation):
     LABEL = "min"
+
+    @classmethod
+    def attribute_type(cls, expression_type: type) -> type:
+        return super().attribute_type(expression_type)
 
     def compare(self, left_value, right_value):
         return left_value < right_value

--- a/nacc_attribute_deriver/symbol_table.py
+++ b/nacc_attribute_deriver/symbol_table.py
@@ -2,13 +2,15 @@ from collections import deque
 from typing import Any, Dict, Iterator, MutableMapping, Optional
 
 
-class SymbolTable(MutableMapping):
+class SymbolTable(MutableMapping[str, Any]):
     """Implements a dictionary like object for using metadata paths as keys."""
 
     def __init__(
-        self, symbol_dict: Optional[MutableMapping] = None, separator: str = "."
+        self,
+        symbol_dict: Optional[MutableMapping[str, Any]] = None,
+        separator: str = ".",
     ) -> None:
-        self.__table: Dict[Any, Any] = {}
+        self.__table: Dict[str, Any] = {}
         self.__separator = separator
 
         # interpret metadata paths
@@ -21,7 +23,7 @@ class SymbolTable(MutableMapping):
         key_list = deque(key.split(self.__separator))
         while key_list:
             sub_key = key_list.popleft()
-            obj = table.get(sub_key)
+            obj = table.get(sub_key, None)
             if not obj:
                 if not key_list:
                     table[sub_key] = value
@@ -76,7 +78,7 @@ class SymbolTable(MutableMapping):
     def __delitem__(self, key: Any) -> None:
         return
 
-    def __iter__(self) -> Iterator:
+    def __iter__(self) -> Iterator[str]:
         return self.__table.__iter__()
 
     def __len__(self) -> int:
@@ -91,5 +93,5 @@ class SymbolTable(MutableMapping):
 
         return self.to_dict() == other.to_dict()
 
-    def to_dict(self) -> MutableMapping:
+    def to_dict(self) -> MutableMapping[str, Any]:
         return self.__table

--- a/rule_reflection/BUILD
+++ b/rule_reflection/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/rule_reflection/inspect_rule_types.py
+++ b/rule_reflection/inspect_rule_types.py
@@ -1,0 +1,137 @@
+"""Computes the types of derived attributes."""
+
+import argparse
+import logging
+import sys
+from csv import DictReader, DictWriter
+from importlib import resources
+from inspect import signature
+from typing import List, Union, get_args, get_origin
+
+from pydantic import BaseModel, ValidationError
+
+from nacc_attribute_deriver import config
+from nacc_attribute_deriver.attributes.attribute_collection import (
+    AttributeCollectionRegistry,
+)
+from nacc_attribute_deriver.schema.schema import RuleFileModel
+
+log = logging.getLogger(__name__)
+
+
+def type_string(type_object: type) -> str:
+    """Returns the type as a string.
+
+    Args:
+      type_object: the type
+    Returns:
+      the type as a string
+    """
+    if type_object is type(None):
+        return "None"
+
+    if hasattr(type_object, "__pydantic_generic_metadata__"):
+        origin = type_object.__pydantic_generic_metadata__["origin"]  # type: ignore
+        args = type_object.__pydantic_generic_metadata__["args"]  # type: ignore
+    else:
+        origin = get_origin(type_object)
+        args = get_args(type_object)
+
+    if not origin:
+        return type_object.__name__
+
+    if origin is Union and type(None) in args:
+        str_args = [type_string(arg) for arg in args if arg is not type(None)]  # type: ignore
+        return f"Optional[{', '.join(str_args)}]"
+
+    str_args = [type_string(arg) for arg in args]  # type: ignore
+    return f"{origin.__name__}[{', '.join(str_args)}]"  # type: ignore
+
+
+class TypeWrapper:
+    """Wrapper for a type."""
+
+    def __init__(self, wrapped_type: type) -> None:
+        self.wrapped_type = wrapped_type
+
+    def __str__(self) -> str:
+        return type_string(self.wrapped_type)
+
+    def is_optional(self) -> bool:
+        """Indicates whether this type is optional."""
+
+        return get_origin(self.wrapped_type) is Union and type(None) in get_args(
+            self.wrapped_type
+        )
+
+
+class RuleType(BaseModel):
+    attribute: str
+    attribute_type: str
+    operation: str
+    expression: str
+    expression_type: str
+
+
+def parse_arguments():
+    parser = argparse.ArgumentParser(description="list source attributes in data model")
+    parser.add_argument("--output", "-o", help="path to save output file")
+    return parser.parse_args()
+
+
+def main():
+    args = parse_arguments()
+    output_file = args.output if args.output else "rule-types.csv"
+
+    instance_collections = AttributeCollectionRegistry.get_attribute_methods()
+    rules_file = resources.files(config).joinpath("curation_rules.csv")
+    with rules_file.open("r") as file_stream:
+        reader = DictReader(file_stream)
+        if not reader.fieldnames:
+            log.error("Expecting fieldnames in rules file.")
+            sys.exit(1)
+
+        rule_types: List[RuleType] = []
+        for row in reader:
+            try:
+                rule_schema = RuleFileModel.model_validate(row)
+            except ValidationError as error:
+                log.error("Rule validation error: %s", str(error))
+                continue
+
+            # location, operation, type
+            expression = instance_collections.get(f"create_{rule_schema.function}")
+            if not expression:
+                continue
+
+            return_type = signature(expression.function).return_annotation
+            rule_types.append(
+                RuleType(
+                    attribute=rule_schema.location,
+                    attribute_type=str(
+                        TypeWrapper(
+                            rule_schema.assignment.operation.attribute_type(return_type)
+                        )
+                    ),
+                    operation=rule_schema.operation,
+                    expression=rule_schema.function,
+                    expression_type=str(TypeWrapper(return_type)),
+                )
+            )
+
+        with open(output_file, "w", encoding="utf-8") as out_file:
+            fieldnames = [
+                "attribute",
+                "attribute_type",
+                "operation",
+                "expression",
+                "expression_type",
+            ]
+            writer = DictWriter(out_file, fieldnames=fieldnames)
+            writer.writeheader()
+            for rule_type in rule_types:
+                writer.writerow(rule_type.model_dump())
+
+
+if __name__ == "__main__":
+    main()

--- a/rule_reflection/inspect_rule_types.py
+++ b/rule_reflection/inspect_rule_types.py
@@ -79,7 +79,7 @@ def parse_arguments():
     return parser.parse_args()
 
 
-def main():
+def main() -> None:
     args = parse_arguments()
     output_file = args.output if args.output else "rule-types.csv"
 

--- a/tests/schema/test_attribute_types.py
+++ b/tests/schema/test_attribute_types.py
@@ -129,8 +129,11 @@ class TestOperationAttributeType:
         wrapper = DateTaggedValue(date=date(year=2025, month=1, day=10), value=value)
         assert type(wrapper) is DateTaggedValue
         operation.evaluate(table=table, value=wrapper, attribute="date-tagged")
-        assert operation.attribute_type(DateTaggedValue[str]) is DateTaggedValue[type(value)]
-        assert type(table.get("date-tagged")['value']) is type(value)  # type: ignore
+        assert (
+            operation.attribute_type(DateTaggedValue[str])
+            is DateTaggedValue[type(value)]
+        )
+        assert type(table.get("date-tagged")["value"]) is type(value)  # type: ignore
 
         value = "blah"
         wrapper = [value]
@@ -158,8 +161,11 @@ class TestOperationAttributeType:
         wrapper = DateTaggedValue(date=date(year=2025, month=1, day=10), value=value)
         assert type(wrapper) is DateTaggedValue
         operation.evaluate(table=table, value=wrapper, attribute="date-tagged")
-        assert operation.attribute_type(DateTaggedValue[str]) is DateTaggedValue[type(value)]
-        assert type(table.get("date-tagged")['value']) is type(value)  # type: ignore
+        assert (
+            operation.attribute_type(DateTaggedValue[str])
+            is DateTaggedValue[type(value)]
+        )
+        assert type(table.get("date-tagged")["value"]) is type(value)  # type: ignore
 
         value = "blah"
         wrapper = [value]

--- a/tests/schema/test_attribute_types.py
+++ b/tests/schema/test_attribute_types.py
@@ -1,0 +1,225 @@
+"""Tests for the attribute_type meta-methods for Operations to make sure they
+match the types set by the operation."""
+
+from datetime import date
+from types import NoneType
+from typing import List
+
+import pytest
+from nacc_attribute_deriver.attributes.base.namespace import DateTaggedValue
+from nacc_attribute_deriver.schema.operation import (
+    InitialOperation,
+    LatestOperation,
+    MinOperation,
+    NoAssignment,
+    OperationError,
+    SetOperation,
+    SortedListOperation,
+    UpdateOperation,
+)
+from nacc_attribute_deriver.symbol_table import SymbolTable
+
+
+class TestOperationAttributeType:
+    def test_update(self):
+        table = SymbolTable()
+        operation = UpdateOperation()
+
+        value = None
+        operation.evaluate(table=table, value=value, attribute="empty")
+        assert operation.attribute_type(type(value)) is type(table.get("empty"))
+
+        value = "blah"
+        operation.evaluate(table=table, value=value, attribute="string")
+        assert operation.attribute_type(type(value)) is type(table.get("string"))
+
+        value = "blah"
+        wrapper = DateTaggedValue(date=date(year=2025, month=1, day=10), value=value)
+        operation.evaluate(table=table, value=wrapper, attribute="date-tagged")
+        assert operation.attribute_type(type(value)) is type(table.get("date-tagged"))
+
+        value = date(year=2025, month=1, day=10)
+        operation.evaluate(table=table, value=value, attribute="date")
+        assert operation.attribute_type(type(value)) is type(table.get("date"))
+
+    def test_set(self):
+        """Tests the set operation.
+
+        A couple things:
+        - we have to deconstruct the value in the symbol table to test the types
+          because a list object doesn't carry it's full type.
+        - typing here assumes the rules are well-behaved in the sense of not
+          adding different types to the same set.
+        """
+        table = SymbolTable()
+        operation = SetOperation()
+
+        value = None
+        operation.evaluate(table=table, value=value, attribute="none-case")
+        assert operation.attribute_type(type(value)) is List
+        assert type(table.get("none-case")) is list
+
+        value = "blah"
+        operation.evaluate(table=table, value=value, attribute="single-value")
+        assert operation.attribute_type(type(value)) is List[type(value)]
+        assert type(table.get("single-value")[0]) is type(value)  # type: ignore
+
+        value = "blah"
+        wrapper = DateTaggedValue(date=date(year=2025, month=1, day=10), value=value)
+        operation.evaluate(table=table, value=wrapper, attribute="date-tagged")
+        assert operation.attribute_type(type(value)) is List[type(value)]
+        assert type(table.get("date-tagged")[0]) is type(value)  # type: ignore
+
+        value = "blah"
+        wrapper = [value]
+        operation.evaluate(table=table, value=wrapper, attribute="list-wrapped")
+        assert operation.attribute_type(type(value)) is List[type(value)]
+        assert type(table.get("list-wrapped")[0]) is type(value)  # type: ignore
+
+    def test_sorted_list(self):
+        """Tests the sorted list operation.
+
+        A couple things:
+        - we have to deconstruct the value in the symbol table to test the types
+          because a list object doesn't carry it's full type.
+        - typing here assumes the rules are well-behaved in the sense of not
+          adding different types to the same list.
+        """
+        table = SymbolTable()
+        operation = SortedListOperation()
+
+        value = None
+        operation.evaluate(table=table, value=value, attribute="none-case")
+        assert operation.attribute_type(type(value)) is List
+        assert type(table.get("none-case")) is list
+
+        value = "blah"
+        operation.evaluate(table=table, value=value, attribute="single-value")
+        assert operation.attribute_type(type(value)) is List[type(value)]
+        assert type(table.get("single-value")[0]) is type(value)  # type: ignore
+
+        value = "blah"
+        wrapper = DateTaggedValue(date=date(year=2025, month=1, day=10), value=value)
+        operation.evaluate(table=table, value=wrapper, attribute="date-tagged")
+        assert operation.attribute_type(type(value)) is List[type(value)]
+        assert type(table.get("date-tagged")[0]) is type(value)  # type: ignore
+
+        value = "blah"
+        wrapper = [value]
+        operation.evaluate(table=table, value=wrapper, attribute="list-wrapped")
+        assert operation.attribute_type(type(value)) is List[type(value)]
+        assert type(table.get("list-wrapped")[0]) is type(value)  # type: ignore
+
+    def test_initial(self):
+        table = SymbolTable()
+        operation = InitialOperation()
+
+        value = None
+        operation.evaluate(table=table, value=value, attribute="none-case")
+        assert operation.attribute_type(type(value)) is NoAssignment
+        assert type(table.get("none-case")) is NoneType
+
+        value = "blah"
+        with pytest.raises(OperationError):
+            operation.evaluate(table=table, value=value, attribute="single-value")
+        assert operation.attribute_type(type(value)) is NoAssignment
+        assert type(table.get("single-value")) is NoneType
+
+        value = "blah"
+        wrapper = DateTaggedValue(date=date(year=2025, month=1, day=10), value=value)
+        assert type(wrapper) is DateTaggedValue
+        operation.evaluate(table=table, value=wrapper, attribute="date-tagged")
+        assert operation.attribute_type(DateTaggedValue[str]) is DateTaggedValue[type(value)]
+        assert type(table.get("date-tagged")['value']) is type(value)  # type: ignore
+
+        value = "blah"
+        wrapper = [value]
+        with pytest.raises(OperationError):
+            operation.evaluate(table=table, value=wrapper, attribute="list-wrapped")
+        assert operation.attribute_type(type(wrapper)) is NoAssignment
+        assert type(table.get("list-wrapped")) is NoneType
+
+    def test_latest(self):
+        table = SymbolTable()
+        operation = LatestOperation()
+
+        value = None
+        operation.evaluate(table=table, value=value, attribute="none-case")
+        assert operation.attribute_type(type(value)) is NoAssignment
+        assert type(table.get("none-case")) is NoneType
+
+        value = "blah"
+        with pytest.raises(OperationError):
+            operation.evaluate(table=table, value=value, attribute="single-value")
+        assert operation.attribute_type(type(value)) is NoAssignment
+        assert type(table.get("single-value")) is NoneType
+
+        value = "blah"
+        wrapper = DateTaggedValue(date=date(year=2025, month=1, day=10), value=value)
+        assert type(wrapper) is DateTaggedValue
+        operation.evaluate(table=table, value=wrapper, attribute="date-tagged")
+        assert operation.attribute_type(DateTaggedValue[str]) is DateTaggedValue[type(value)]
+        assert type(table.get("date-tagged")['value']) is type(value)  # type: ignore
+
+        value = "blah"
+        wrapper = [value]
+        with pytest.raises(OperationError):
+            operation.evaluate(table=table, value=wrapper, attribute="list-wrapped")
+        assert operation.attribute_type(type(wrapper)) is NoAssignment
+        assert type(table.get("list-wrapped")) is NoneType
+
+    def test_min(self):
+        table = SymbolTable()
+        operation = MinOperation()
+
+        value = None
+        operation.evaluate(table=table, value=value, attribute="none-case")
+        assert operation.attribute_type(type(value)) is NoneType
+        assert type(table.get("none-case")) is NoneType
+
+        value = "blah"
+        operation.evaluate(table=table, value=value, attribute="single-value")
+        assert operation.attribute_type(type(value)) is str
+        assert type(table.get("single-value")) is str
+
+        value = "blah"
+        wrapper = DateTaggedValue(date=date(year=2025, month=1, day=10), value=value)
+        assert type(wrapper) is DateTaggedValue
+        operation.evaluate(table=table, value=wrapper, attribute="date-tagged")
+        assert operation.attribute_type(DateTaggedValue[type(value)]) is type(value)
+        assert type(table.get("date-tagged")) is type(value)
+
+        value = "blah"
+        wrapper = [value]
+        operation.evaluate(table=table, value=wrapper, attribute="list-wrapped")
+        assert operation.attribute_type(List[type(value)]) is List[type(value)]
+        assert type(table.get("list-wrapped")) is list
+        assert type(table.get("list-wrapped")[0]) is type(value)  # type: ignore
+
+    def test_max(self):
+        table = SymbolTable()
+        operation = MinOperation()
+
+        value = None
+        operation.evaluate(table=table, value=value, attribute="none-case")
+        assert operation.attribute_type(type(value)) is NoneType
+        assert type(table.get("none-case")) is NoneType
+
+        value = "blah"
+        operation.evaluate(table=table, value=value, attribute="single-value")
+        assert operation.attribute_type(type(value)) is str
+        assert type(table.get("single-value")) is str
+
+        value = "blah"
+        wrapper = DateTaggedValue(date=date(year=2025, month=1, day=10), value=value)
+        assert type(wrapper) is DateTaggedValue
+        operation.evaluate(table=table, value=wrapper, attribute="date-tagged")
+        assert operation.attribute_type(DateTaggedValue[type(value)]) is type(value)
+        assert type(table.get("date-tagged")) is type(value)
+
+        value = "blah"
+        wrapper = [value]
+        operation.evaluate(table=table, value=wrapper, attribute="list-wrapped")
+        assert operation.attribute_type(List[type(value)]) is List[type(value)]
+        assert type(table.get("list-wrapped")) is list
+        assert type(table.get("list-wrapped")[0]) is type(value)  # type: ignore


### PR DESCRIPTION
Adds the ability to infer the type of the value returned by curation rules.

1. Adds `attribute_type` methods to the operations to that computes the type set by the operation for particular value types. These do not use reflection on the code and so tests are also added to make sure the operation return value corresponds to the computed `attribute_type`.
2. Adds `rule_reflection/inspect_rule_types.py` that scrapes the return types of the attribute `_create` methods for the curation rules and generates a table indicating the type for each rule.


